### PR TITLE
Build with swift instead of xcodebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 *.log
 
 swift/main
-swift/build
+swift/.build
 
 .DS_Store
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Matheus Fernandes <npm@matheus.top> (https://matheus.top)",
   "scripts": {
     "test": "xo",
-    "build": "cd swift && xcodebuild && mv build/release/aperture main && rm -r build",
+    "build": "cd swift && swift build -c release && mv .build/release/aperture main && rm -r .build",
     "postinstall": "npm run build"
   },
   "dependencies": {

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,0 +1,5 @@
+import PackageDescription
+
+let package = Package(
+    name: "aperture.js"
+)


### PR DESCRIPTION
Change the build script to build with `swift` instead of `xcodebuild`.

This is part of #19. Currently `aperture` can't be build on linux (so maybe this is part of #7 as well 🤔 but haven't looked in detail inside the PR) which means it can't build in `Docker` as well.

`swift` is available on multiple operating systems (e.g. linux) but `xcodebuild` not.
So changing the build script to build with `swift` you only have to install `swift` on your given OS and you are fine to build `aperture` 🎉 

Probably you want to modify the `Package.swift` to fits your needs. But I should that would be done later by you :)