### PR TITLE
Ship aperture as binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "xo",
     "build": "cd swift && xcodebuild && mv build/release/aperture main && rm -r build",
-    "postinstall": "npm run build"
+    "prepublish": "npm run build"
   },
   "dependencies": {
     "execa": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "devDependencies": {
     "xo": "^0.17.0"
   },
+  "files": [
+      "index.js",
+      "swift/main"
+  ],
   "xo": {
     "space": true,
     "esnext": true


### PR DESCRIPTION
This will fix #19 (hopefully) 😄..

The npm package now includes "only" the `aperture-compiled-swift binary` and the `index.js`.
Beside of the stuff which is always packed with `npm pack` like `README` and `license`.

I've tested it like this:

1. run `npm pack`
2. uploaded the tgz to [github releases](https://github.com/StefMa/aperture.js/releases/tag/v0.1.0) 
3. Used these url as dependency in another project:
```json
  "dependencies": {
    "aperture.js": "https://github.com/StefMa/aperture.js/releases/download/v0.1.0/aperture.js-0.1.0.tgz"
  },
```
4. run `yarn/npm install`
5. run my app which can record the screen with aperture \o/